### PR TITLE
Rework instance and static to have parallel APIs

### DIFF
--- a/lib/ghrequestor.js
+++ b/lib/ghrequestor.js
@@ -2,65 +2,6 @@ const extend = require('extend');
 const Q = require('q');
 const request = require('requestretry');
 
-  /**
-   * Attempt to get the GitHub resource at the given target URL.  The callback supplied, if any,
-   * is called when the resource has been retrieved or an irrecoverable problem has been encountered.
-   * If a callback is not supplied, a promise is returned. The promise will be resolved with the
-   * response on success or rejected with an error object. Note that responses with statusCode >=300 are not
-   * errors -- the promise will be resolved with such a response.
-   * @param {string} target URL to fetch
-   * @param {object} [options] Options to use through the retry and request process.
-   * @param {function} [callback] Function to call on completion of the retrieval.
-   * @returns {null|promise} null if a callback is supplied. A promise otherwise.
-   */
-function get(target, options = {}, callback = null) {
-    return new GHRequestor(options)._get(target, callback);
-}
-
-module.exports.get = get;
-
-  /**
-   * Attempt to get all pages related to the given target URL.  The callback supplied, if any,
-   * is called when all pages have been retrieved or an irrecoverable problem has been encountered.
-   * If a callback is not supplied, a promise is returned. The promise will be resolved with the
-   * collected bodies on success or rejected with an error object.  The error may have a response property
-   * containing the response that caused the failure.
-   * @param {string} target URL to fetch and paginate
-   * @param {object} [options] Options to use through the retry and request process.
-   * @param {function} [callback] Function to call on completion of the retrieval.
-   * @returns {null|promise} null if a callback is supplied. A promise otherwise.
-   */
-function getAll(target, options = {}, callback = null) {
-    return new GHRequestor(options).getAll(target, callback);
-}
-
-module.exports.getAll = getAll;
-
-module.exports.getInstance = function (options) {
-    return new Requestor(options);
-}
-
-class Requestor {
-    constructor(options = {}) {
-        this.defaultOptions = options;
-    }
-    get(target, options, callback) {
-        if (typeof options == 'function') {
-            callback = options;
-            options = null;
-        };
-        return get(target, options ? options : this.defaultOptions, callback);
-    }
-    getAll(target, options, callback) {
-        if (typeof options == 'function') {
-            callback = options;
-            options = null;
-        };
-        return getAll(target, options ? options : this.defaultOptions, callback);
-    }
-}
-
-
 class GHRequestor {
   constructor(givenOptions = {}) {
     const defaultOptions = GHRequestor._defaultOptions;
@@ -240,3 +181,5 @@ class GHRequestor {
     return forbiddenDelay || this.options.retryDelay;
   }
 }
+
+module.exports = GHRequestor;

--- a/lib/requestor.js
+++ b/lib/requestor.js
@@ -1,0 +1,59 @@
+const GHRequestor = require('./ghrequestor');
+  /**
+   * Attempt to get the GitHub resource at the given target URL.  The callback supplied, if any,
+   * is called when the resource has been retrieved or an irrecoverable problem has been encountered.
+   * If a callback is not supplied, a promise is returned. The promise will be resolved with the
+   * response on success or rejected with an error object. Note that responses with statusCode >=300 are not
+   * errors -- the promise will be resolved with such a response.
+   * @param {string} target URL to fetch
+   * @param {object} [options] Options to use through the retry and request process.
+   * @param {function} [callback] Function to call on completion of the retrieval.
+   * @returns {null|promise} null if a callback is supplied. A promise otherwise.
+   */
+function get(target, options = {}, callback = null) {
+    return new GHRequestor(options)._get(target, callback);
+}
+
+module.exports.get = get;
+
+  /**
+   * Attempt to get all pages related to the given target URL.  The callback supplied, if any,
+   * is called when all pages have been retrieved or an irrecoverable problem has been encountered.
+   * If a callback is not supplied, a promise is returned. The promise will be resolved with the
+   * collected bodies on success or rejected with an error object.  The error may have a response property
+   * containing the response that caused the failure.
+   * @param {string} target URL to fetch and paginate
+   * @param {object} [options] Options to use through the retry and request process.
+   * @param {function} [callback] Function to call on completion of the retrieval.
+   * @returns {null|promise} null if a callback is supplied. A promise otherwise.
+   */
+function getAll(target, options = {}, callback = null) {
+    return new GHRequestor(options).getAll(target, callback);
+}
+
+module.exports.getAll = getAll;
+
+module.exports.getInstance = function (options) {
+    return new Requestor(options);
+}
+
+class Requestor {
+    constructor(options = {}) {
+        this.defaultOptions = options;
+    }
+    get(target, options, callback) {
+        if (typeof options == 'function') {
+            callback = options;
+            options = null;
+        };
+        return get(target, options ? options : this.defaultOptions, callback);
+    }
+    getAll(target, options, callback) {
+        if (typeof options == 'function') {
+            callback = options;
+            options = null;
+        };
+        return getAll(target, options ? options : this.defaultOptions, callback);
+    }
+}
+

--- a/test/ghrequestorTests.js
+++ b/test/ghrequestorTests.js
@@ -2,32 +2,33 @@ const assert = require('chai').assert;
 const chai = require('chai');
 const expect = require('chai').expect;
 const extend = require('extend');
-const requestor = require('../lib/ghrequestor.js');
+const requestor = require('../lib/requestor.js');
+const GHRequestor = require('../lib/ghrequestor.js')
 const request = require('requestretry');
 
 const urlHost = 'https://test.com';
 
-// describe('Request option merging', () => {
-//   it('should merge and override properties', () => {
-//     const result = new requestor.GHRequestor({
-//       retryDelay: 10,
-//       testProperty: 'test value'
-//     });
-//     expect(result.options.retryDelay).to.equal(10);
-//     expect(result.options.testProperty).to.equal('test value');
-//   });
+describe('Request option merging', () => {
+  it('should merge and override properties', () => {
+    const result = new GHRequestor({
+      retryDelay: 10,
+      testProperty: 'test value'
+    });
+    expect(result.options.retryDelay).to.equal(10);
+    expect(result.options.testProperty).to.equal('test value');
+  });
 
-//   it('should merge and override headers', () => {
-//     const result = new requestor.GHRequestor({
-//       headers: {
-//         'User-Agent': 'test agent',
-//         authorization: 'test auth'
-//       }
-//     });
-//     expect(result.options.headers['User-Agent']).to.equal('test agent');
-//     expect(result.options.headers.authorization).to.equal('test auth');
-//   });
-// });
+  it('should merge and override headers', () => {
+    const result = new GHRequestor({
+      headers: {
+        'User-Agent': 'test agent',
+        authorization: 'test auth'
+      }
+    });
+    expect(result.options.headers['User-Agent']).to.equal('test agent');
+    expect(result.options.headers.authorization).to.equal('test auth');
+  });
+});
 
 describe('Request retry and success', () => {
   it('should be able to get a single page resource', () => {


### PR DESCRIPTION
Also makes instances thread safe, though it does consume more memory. Note that you can use GHRequestor directly, but the way the code is structured discourages it.